### PR TITLE
fix trigger index bug

### DIFF
--- a/src/trigger.js
+++ b/src/trigger.js
@@ -59,7 +59,7 @@
             // bind event
             host.triggers.on("click.switchTrigger", function (e) {
                 e.preventDefault();
-                index = $(this).index();
+                index = host.triggers.index( $(this) );
 
                 host._cancelDelayTimer();
                 host.switchTo(index);


### PR DESCRIPTION
在这种情况下

``` html
<ul class="trigger">
    <li>
        <a href="javascript:;">1</a>
        <a href="javascript:;">2</a>
    </li>
    <li>
        <a href="javascript:;">3</a>
    </li>
</ul>
```

``` javascript
$('#xx').switchable({triggers: '.trigger a'});
```

a3的index会变成0就变成了两个index为0的trigger。

解决办法如下：

``` javascript
// index = $(this).index(); 之前的代码
index = host.triggers.index( $(this) ); // 修改后的代码
```
